### PR TITLE
breaking: change next_exp to int

### DIFF
--- a/api/info.go
+++ b/api/info.go
@@ -68,10 +68,10 @@ type UserInfo struct {
 		FaceNft       int    `json:"face_nft"`
 		FaceNftType   int    `json:"face_nft_type"`
 		LevelInfo     struct {
-			CurrentLevel int    `json:"current_level"`
-			CurrentMin   int    `json:"current_min"`
-			CurrentExp   int    `json:"current_exp"`
-			NextExp      string `json:"next_exp"`
+			CurrentLevel int `json:"current_level"`
+			CurrentMin   int `json:"current_min"`
+			CurrentExp   int `json:"current_exp"`
+			NextExp      int `json:"next_exp"`
 		} `json:"level_info"`
 		Mid            int     `json:"mid"`
 		MobileVerified int     `json:"mobile_verified"`


### PR DESCRIPTION
fix `ERRO[0000] json: cannot unmarshal number into Go struct field .data.level_info.next_exp of type string`

设置 `Cookie` 时出现的类型错误